### PR TITLE
Document `presigned_url/5` example

### DIFF
--- a/lib/ex_aws/s3.ex
+++ b/lib/ex_aws/s3.ex
@@ -1250,6 +1250,13 @@ defmodule ExAws.S3 do
 
   Signed headers can be added to the url by setting option param `:headers` to
   a list of `{"key", "value"}` pairs.
+  
+  ## Example
+  ```
+  :s3
+  |> ExAws.Config.new([])
+  |> ExAws.S3.presigned_url(:get, "my-bucket", "my-object", [])
+  ```
   """
   @spec presigned_url(
           config :: map,


### PR DESCRIPTION
The config parameter is a map by the spec, so it was not clear to me after reading the function docs how to get it or what data should I put on it.

I see that there's an example on the [Bucket as host functionality](https://hexdocs.pm/ex_aws_s3/ExAws.S3.html#module-bucket-as-host-functionality) section, but at least for me it was kind of hidden.